### PR TITLE
Adding a build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore files downloaded from build.sh
+linver_*.tar.gz.txt

--- a/Alpine/build.sh
+++ b/Alpine/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+wget https://www.syncovery.com/linver_x86_64-Web.tar.gz.txt 2>/dev/null
+wget https://www.syncovery.com/linver_guardian_x86_64.tar.gz.txt 2>/dev/null
+wget https://www.syncovery.com/linver_rs_x86_64.tar.gz.txt 2>/dev/null
+
+mapfile -t syncovery <linver_x86_64-Web.tar.gz.txt
+mapfile -t guardian  <linver_guardian_x86_64.tar.gz.txt
+mapfile -t remote    <linver_rs_x86_64.tar.gz.txt
+
+SYNCOVERY_DOWNLOADLINK=${syncovery[2]}
+VERSION=${syncovery[4]}
+GUARD_DOWNLOADLINK=${guardian[2]}
+REMOTE_DOWNLOADLINK=${remote[2]}
+
+docker build . -t docker_syncovery:${VERSION}-alpine \
+  --build-arg SYNCOVERY_DOWNLOADLINK=${SYNCOVERY_DOWNLOADLINK} \
+  --build-arg GUARD_DOWNLOADLINK=${GUARD_DOWNLOADLINK} \
+  --build-arg REMOTE_DOWNLOADLINK=${REMOTE_DOWNLOADLINK}
+

--- a/Alpine/build.sh
+++ b/Alpine/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-wget https://www.syncovery.com/linver_x86_64-Web.tar.gz.txt 2>/dev/null
-wget https://www.syncovery.com/linver_guardian_x86_64.tar.gz.txt 2>/dev/null
-wget https://www.syncovery.com/linver_rs_x86_64.tar.gz.txt 2>/dev/null
+wget -O linver_x86_64-Web.tar.gz.txt      https://www.syncovery.com/linver_x86_64-Web.tar.gz.txt      2>/dev/null
+wget -O linver_guardian_x86_64.tar.gz.txt https://www.syncovery.com/linver_guardian_x86_64.tar.gz.txt 2>/dev/null
+wget -O linver_rs_x86_64.tar.gz.txt       https://www.syncovery.com/linver_rs_x86_64.tar.gz.txt       2>/dev/null
 
 mapfile -t syncovery <linver_x86_64-Web.tar.gz.txt
 mapfile -t guardian  <linver_guardian_x86_64.tar.gz.txt
@@ -17,4 +17,3 @@ docker build . -t docker_syncovery:${VERSION}-alpine \
   --build-arg SYNCOVERY_DOWNLOADLINK=${SYNCOVERY_DOWNLOADLINK} \
   --build-arg GUARD_DOWNLOADLINK=${GUARD_DOWNLOADLINK} \
   --build-arg REMOTE_DOWNLOADLINK=${REMOTE_DOWNLOADLINK}
-

--- a/Ubuntu/build.sh
+++ b/Ubuntu/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-wget https://www.syncovery.com/linver_x86_64-Web.tar.gz.txt 2>/dev/null
-wget https://www.syncovery.com/linver_guardian_x86_64.tar.gz.txt 2>/dev/null
-wget https://www.syncovery.com/linver_rs_x86_64.tar.gz.txt 2>/dev/null
+wget -O linver_x86_64-Web.tar.gz.txt      https://www.syncovery.com/linver_x86_64-Web.tar.gz.txt      2>/dev/null
+wget -O linver_guardian_x86_64.tar.gz.txt https://www.syncovery.com/linver_guardian_x86_64.tar.gz.txt 2>/dev/null
+wget -O linver_rs_x86_64.tar.gz.txt       https://www.syncovery.com/linver_rs_x86_64.tar.gz.txt       2>/dev/null
 
 mapfile -t syncovery <linver_x86_64-Web.tar.gz.txt
 mapfile -t guardian  <linver_guardian_x86_64.tar.gz.txt
@@ -17,4 +17,3 @@ docker build . -t docker_syncovery:${VERSION}-ubuntu \
   --build-arg SYNCOVERY_DOWNLOADLINK=${SYNCOVERY_DOWNLOADLINK} \
   --build-arg GUARD_DOWNLOADLINK=${GUARD_DOWNLOADLINK} \
   --build-arg REMOTE_DOWNLOADLINK=${REMOTE_DOWNLOADLINK}
-

--- a/Ubuntu/build.sh
+++ b/Ubuntu/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+wget https://www.syncovery.com/linver_x86_64-Web.tar.gz.txt 2>/dev/null
+wget https://www.syncovery.com/linver_guardian_x86_64.tar.gz.txt 2>/dev/null
+wget https://www.syncovery.com/linver_rs_x86_64.tar.gz.txt 2>/dev/null
+
+mapfile -t syncovery <linver_x86_64-Web.tar.gz.txt
+mapfile -t guardian  <linver_guardian_x86_64.tar.gz.txt
+mapfile -t remote    <linver_rs_x86_64.tar.gz.txt
+
+SYNCOVERY_DOWNLOADLINK=${syncovery[2]}
+VERSION=${syncovery[4]}
+GUARD_DOWNLOADLINK=${guardian[2]}
+REMOTE_DOWNLOADLINK=${remote[2]}
+
+docker build . -t docker_syncovery:${VERSION}-ubuntu \
+  --build-arg SYNCOVERY_DOWNLOADLINK=${SYNCOVERY_DOWNLOADLINK} \
+  --build-arg GUARD_DOWNLOADLINK=${GUARD_DOWNLOADLINK} \
+  --build-arg REMOTE_DOWNLOADLINK=${REMOTE_DOWNLOADLINK}
+


### PR DESCRIPTION
Following https://github.com/MyUncleSam/docker-syncovery/issues/4

This PR adds a build script for both variant (Ubuntu and Alpine).
It downloads the linver files, extract the URL and versions and launch the build accordingly with proper tagging as `docker-syncovery:<version>-<variant>`

Very rough and basic, no error checking, only supports x86-64
